### PR TITLE
Add Teacher Dashboard (behind feature flag)

### DIFF
--- a/app/api/classes/[classId]/roster/[studentId]/route.ts
+++ b/app/api/classes/[classId]/roster/[studentId]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/require-role';
+import { servicePrisma } from '@/lib/prisma-service';
+import { authorizeTeacherClass } from '@/lib/classes/authorize-teacher-class';
+
+export const runtime = 'nodejs';
+
+// DELETE /api/classes/[classId]/roster/[studentId] - archive an enrollment
+// (soft remove, not a hard delete - see EnrollmentStatus in schema.prisma)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ classId: string; studentId: string }> }
+) {
+  const auth = await requireRole('TEACHER');
+  if ('error' in auth) return auth.error;
+
+  const { classId, studentId } = await params;
+  const klass = await servicePrisma.class.findUnique({
+    where: { id: classId },
+    select: { teacherId: true },
+  });
+
+  const authz = authorizeTeacherClass({ requestingUserId: auth.userId, klass });
+  if (!authz.authorized) {
+    return NextResponse.json({ error: 'Class not found' }, { status: 404 });
+  }
+
+  const result = await servicePrisma.enrollment.updateMany({
+    where: { classId, studentId, status: 'ACTIVE' },
+    data: { status: 'ARCHIVED' },
+  });
+
+  if (result.count === 0) {
+    return NextResponse.json({ error: 'Enrollment not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/classes/[classId]/roster/route.ts
+++ b/app/api/classes/[classId]/roster/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/require-role';
+import { servicePrisma } from '@/lib/prisma-service';
+import { authorizeTeacherClass } from '@/lib/classes/authorize-teacher-class';
+import { getClassRoster } from '@/lib/classes/get-class-roster';
+
+export const runtime = 'nodejs';
+
+// GET /api/classes/[classId]/roster - roster for one class, teacher-owned only
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ classId: string }> }
+) {
+  const auth = await requireRole('TEACHER');
+  if ('error' in auth) return auth.error;
+
+  const { classId } = await params;
+  const klass = await servicePrisma.class.findUnique({
+    where: { id: classId },
+    select: { teacherId: true },
+  });
+
+  const authz = authorizeTeacherClass({ requestingUserId: auth.userId, klass });
+  if (!authz.authorized) {
+    return NextResponse.json({ error: 'Class not found' }, { status: 404 });
+  }
+
+  const roster = await getClassRoster(classId);
+  return NextResponse.json({ roster });
+}

--- a/app/api/classes/join/route.ts
+++ b/app/api/classes/join/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/require-role';
+import { servicePrisma } from '@/lib/prisma-service';
+
+export const runtime = 'nodejs';
+
+// POST /api/classes/join - student enters a class code, enrolls immediately
+export async function POST(request: NextRequest) {
+  const auth = await requireRole('STUDENT');
+  if ('error' in auth) return auth.error;
+
+  const { code } = await request.json();
+  if (!code || typeof code !== 'string' || !code.trim()) {
+    return NextResponse.json({ error: 'A class code is required' }, { status: 400 });
+  }
+
+  const klass = await servicePrisma.class.findUnique({
+    where: { code: code.trim().toUpperCase() },
+  });
+
+  if (!klass) {
+    return NextResponse.json({ error: 'Invalid class code' }, { status: 404 });
+  }
+
+  // Upsert so a student re-entering a code after being archived reactivates
+  // their enrollment instead of colliding with the unique constraint.
+  const enrollment = await servicePrisma.enrollment.upsert({
+    where: { classId_studentId: { classId: klass.id, studentId: auth.userId } },
+    update: { status: 'ACTIVE' },
+    create: { classId: klass.id, studentId: auth.userId },
+  });
+
+  return NextResponse.json(
+    { enrollment, class: { id: klass.id, name: klass.name } },
+    { status: 201 }
+  );
+}

--- a/app/api/classes/route.ts
+++ b/app/api/classes/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/require-role';
+import { servicePrisma } from '@/lib/prisma-service';
+import { generateUniqueClassCode } from '@/lib/classes/generate-class-code';
+
+export const runtime = 'nodejs';
+
+// POST /api/classes - create a class owned by the authenticated teacher
+export async function POST(request: NextRequest) {
+  const auth = await requireRole('TEACHER');
+  if ('error' in auth) return auth.error;
+
+  const { name } = await request.json();
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return NextResponse.json({ error: 'A class name is required' }, { status: 400 });
+  }
+
+  const code = await generateUniqueClassCode(async (candidate) => {
+    const existing = await servicePrisma.class.findUnique({ where: { code: candidate } });
+    return existing !== null;
+  });
+
+  const klass = await servicePrisma.class.create({
+    data: { name: name.trim(), code, teacherId: auth.userId },
+  });
+
+  return NextResponse.json({ class: klass }, { status: 201 });
+}
+
+// GET /api/classes - list the authenticated teacher's own classes
+export async function GET() {
+  const auth = await requireRole('TEACHER');
+  if ('error' in auth) return auth.error;
+
+  const classes = await servicePrisma.class.findMany({
+    where: { teacherId: auth.userId },
+    include: { _count: { select: { enrollments: { where: { status: 'ACTIVE' } } } } },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return NextResponse.json({ classes });
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -17,6 +17,8 @@ import type { Session } from '@supabase/supabase-js';
 import { normalizeRole } from '@/lib/auth/resolve-signup-role';
 import { resolvePostLoginDestination } from '@/lib/auth/resolve-post-login-destination';
 
+const isTeacherDashboardEnabled = process.env.NEXT_PUBLIC_TEACHER_DASHBOARD === 'true';
+
 function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -237,9 +239,10 @@ function LoginPageContent() {
       announceToScreenReader('Login successful! Redirecting...');
       
       // Get redirectTo from URL, or fall back to the role-based default
-      // (currently /catalog for every role until Teacher Dashboard ships)
       const role = normalizeRole((user?.user_metadata as { role?: string } | undefined)?.role);
-      const defaultRedirect = resolvePostLoginDestination(role);
+      const defaultRedirect = resolvePostLoginDestination(role, {
+        teacherDashboardEnabled: isTeacherDashboardEnabled,
+      });
       const rawRedirectTo = searchParams.get('redirectTo') || defaultRedirect;
       const redirectTo =
         typeof rawRedirectTo === 'string' && rawRedirectTo.startsWith('/')

--- a/app/dashboard/classes/[classId]/page.tsx
+++ b/app/dashboard/classes/[classId]/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useAuth } from '@/components/SimpleAuthProvider';
+
+interface RosterEntry {
+  enrollmentId: string;
+  studentId: string;
+  name: string | null;
+  email: string;
+  joinedAt: string;
+  booksRead: number;
+  lastActivity: string | null;
+}
+
+export default function ClassRosterPage() {
+  const router = useRouter();
+  const params = useParams<{ classId: string }>();
+  const { user, loading, role } = useAuth();
+  const [roster, setRoster] = useState<RosterEntry[] | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace('/auth/login');
+      return;
+    }
+    if (role !== 'TEACHER') {
+      router.replace('/catalog');
+    }
+  }, [loading, user, role, router]);
+
+  useEffect(() => {
+    if (!user || role !== 'TEACHER') return;
+    fetch(`/api/classes/${params.classId}/roster`)
+      .then(async (res) => {
+        if (res.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        const data = await res.json();
+        setRoster(data.roster ?? []);
+      })
+      .catch(() => setError('Could not load the roster.'));
+  }, [user, role, params.classId]);
+
+  const handleRemove = async (studentId: string) => {
+    setRemovingId(studentId);
+    setError(null);
+    try {
+      const response = await fetch(`/api/classes/${params.classId}/roster/${studentId}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const result = await response.json();
+        throw new Error(result.error || 'Failed to remove student');
+      }
+      setRoster((prev) => prev?.filter((entry) => entry.studentId !== studentId) ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  if (loading || !user || role !== 'TEACHER') {
+    return null;
+  }
+
+  return (
+    <div className="page-container min-h-screen bg-[var(--bg-primary)] text-[var(--text-primary)]" style={{ padding: '48px 24px' }}>
+      <div className="w-full max-w-3xl mx-auto">
+        <button
+          onClick={() => router.push('/dashboard')}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'var(--text-secondary)',
+            fontSize: '14px',
+            cursor: 'pointer',
+            marginBottom: '16px',
+            padding: 0,
+          }}
+        >
+          &larr; Back to your classes
+        </button>
+
+        <h1 style={{
+          fontSize: '1.75rem',
+          fontWeight: 700,
+          marginBottom: '24px',
+          color: 'var(--text-accent)',
+          fontFamily: 'Playfair Display, serif',
+        }}>
+          Roster
+        </h1>
+
+        {error && (
+          <div role="alert" style={{ color: '#ef4444', fontWeight: 600, marginBottom: '20px', fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+            {error}
+          </div>
+        )}
+
+        {notFound ? (
+          <p style={{ color: 'var(--text-secondary)' }}>Class not found.</p>
+        ) : roster === null ? (
+          <p style={{ color: 'var(--text-secondary)' }}>Loading...</p>
+        ) : roster.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)', fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+            No students have joined yet - share the invite code from your dashboard.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {roster.map((entry) => (
+              <div
+                key={entry.enrollmentId}
+                style={{
+                  background: 'var(--bg-secondary)',
+                  border: '2px solid var(--border-light)',
+                  borderRadius: '16px',
+                  padding: '20px',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <div>
+                  <div style={{ fontSize: '16px', fontWeight: 700, fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+                    {entry.name || entry.email}
+                  </div>
+                  <div style={{ fontSize: '13px', color: 'var(--text-secondary)', marginTop: '4px' }}>
+                    {entry.booksRead} book{entry.booksRead === 1 ? '' : 's'} read
+                    {entry.lastActivity && ` · last active ${new Date(entry.lastActivity).toLocaleDateString()}`}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleRemove(entry.studentId)}
+                  disabled={removingId === entry.studentId}
+                  style={{
+                    background: 'none',
+                    border: '2px solid var(--border-light)',
+                    color: 'var(--text-secondary)',
+                    borderRadius: '10px',
+                    padding: '8px 16px',
+                    fontSize: '13px',
+                    cursor: removingId === entry.studentId ? 'not-allowed' : 'pointer',
+                    opacity: removingId === entry.studentId ? 0.5 : 1,
+                  }}
+                >
+                  {removingId === entry.studentId ? 'Removing...' : 'Remove'}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/classes/[classId]/page.tsx
+++ b/app/dashboard/classes/[classId]/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useAuth } from '@/components/SimpleAuthProvider';
 
+const isTeacherDashboardEnabled = process.env.NEXT_PUBLIC_TEACHER_DASHBOARD === 'true';
+
 interface RosterEntry {
   enrollmentId: string;
   studentId: string;
@@ -24,6 +26,10 @@ export default function ClassRosterPage() {
   const [removingId, setRemovingId] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isTeacherDashboardEnabled) {
+      router.replace('/catalog');
+      return;
+    }
     if (loading) return;
     if (!user) {
       router.replace('/auth/login');
@@ -67,7 +73,7 @@ export default function ClassRosterPage() {
     }
   };
 
-  if (loading || !user || role !== 'TEACHER') {
+  if (!isTeacherDashboardEnabled || loading || !user || role !== 'TEACHER') {
     return null;
   }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/SimpleAuthProvider';
 
+const isTeacherDashboardEnabled = process.env.NEXT_PUBLIC_TEACHER_DASHBOARD === 'true';
+
 interface ClassSummary {
   id: string;
   name: string;
@@ -21,6 +23,10 @@ export default function TeacherDashboardPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isTeacherDashboardEnabled) {
+      router.replace('/catalog');
+      return;
+    }
     if (loading) return;
     if (!user) {
       router.replace('/auth/login');
@@ -64,7 +70,7 @@ export default function TeacherDashboardPage() {
     }
   };
 
-  if (loading || !user || role !== 'TEACHER') {
+  if (!isTeacherDashboardEnabled || loading || !user || role !== 'TEACHER') {
     return null;
   }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/SimpleAuthProvider';
+
+interface ClassSummary {
+  id: string;
+  name: string;
+  code: string;
+  createdAt: string;
+  _count: { enrollments: number };
+}
+
+export default function TeacherDashboardPage() {
+  const router = useRouter();
+  const { user, loading, role } = useAuth();
+  const [classes, setClasses] = useState<ClassSummary[] | null>(null);
+  const [newClassName, setNewClassName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace('/auth/login');
+      return;
+    }
+    if (role !== 'TEACHER') {
+      router.replace('/catalog');
+    }
+  }, [loading, user, role, router]);
+
+  useEffect(() => {
+    if (!user || role !== 'TEACHER') return;
+    fetch('/api/classes')
+      .then((res) => res.json())
+      .then((data) => setClasses(data.classes ?? []))
+      .catch(() => setError('Could not load your classes.'));
+  }, [user, role]);
+
+  const handleCreateClass = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newClassName.trim()) return;
+
+    setIsCreating(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/classes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newClassName.trim() }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || 'Failed to create class');
+      }
+      setClasses((prev) => [{ ...result.class, _count: { enrollments: 0 } }, ...(prev ?? [])]);
+      setNewClassName('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  if (loading || !user || role !== 'TEACHER') {
+    return null;
+  }
+
+  return (
+    <div className="page-container min-h-screen bg-[var(--bg-primary)] text-[var(--text-primary)]" style={{ padding: '48px 24px' }}>
+      <div className="w-full max-w-3xl mx-auto">
+        <h1 style={{
+          fontSize: '2rem',
+          fontWeight: 700,
+          marginBottom: '8px',
+          color: 'var(--text-accent)',
+          fontFamily: 'Playfair Display, serif',
+        }}>
+          Your classes
+        </h1>
+        <p style={{
+          fontSize: '15px',
+          color: 'var(--text-secondary)',
+          marginBottom: '32px',
+          fontFamily: 'Source Serif Pro, Georgia, serif',
+        }}>
+          Create a class, share the invite code with your students, and see who's joined.
+        </p>
+
+        <form
+          onSubmit={handleCreateClass}
+          style={{
+            display: 'flex',
+            gap: '12px',
+            marginBottom: '32px',
+            background: 'var(--bg-secondary)',
+            border: '2px solid var(--border-light)',
+            borderRadius: '16px',
+            padding: '16px',
+          }}
+        >
+          <input
+            type="text"
+            value={newClassName}
+            onChange={(e) => setNewClassName(e.target.value)}
+            placeholder="e.g. Intermediate ESL - Fall 2026"
+            disabled={isCreating}
+            style={{
+              flex: 1,
+              padding: '12px 16px',
+              borderRadius: '12px',
+              border: '2px solid var(--border-light)',
+              background: 'var(--bg-tertiary)',
+              color: 'var(--text-primary)',
+              fontSize: '15px',
+              fontFamily: 'Source Serif Pro, Georgia, serif',
+            }}
+          />
+          <button
+            type="submit"
+            disabled={isCreating || !newClassName.trim()}
+            style={{
+              padding: '12px 24px',
+              background: 'var(--accent-primary)',
+              color: 'var(--bg-primary)',
+              border: 'none',
+              borderRadius: '12px',
+              fontSize: '15px',
+              fontWeight: 700,
+              fontFamily: 'Source Serif Pro, Georgia, serif',
+              cursor: isCreating ? 'not-allowed' : 'pointer',
+              opacity: isCreating || !newClassName.trim() ? 0.5 : 1,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {isCreating ? 'Creating...' : 'Create class'}
+          </button>
+        </form>
+
+        {error && (
+          <div role="alert" style={{ color: '#ef4444', fontWeight: 600, marginBottom: '20px', fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+            {error}
+          </div>
+        )}
+
+        {classes === null ? (
+          <p style={{ color: 'var(--text-secondary)' }}>Loading...</p>
+        ) : classes.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)', fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+            No classes yet - create one above to get an invite code for your students.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {classes.map((klass) => (
+              <button
+                key={klass.id}
+                onClick={() => router.push(`/dashboard/classes/${klass.id}`)}
+                style={{
+                  textAlign: 'left',
+                  background: 'var(--bg-secondary)',
+                  border: '2px solid var(--border-light)',
+                  borderRadius: '16px',
+                  padding: '20px',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <div>
+                  <div style={{ fontSize: '17px', fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+                    {klass.name}
+                  </div>
+                  <div style={{ fontSize: '14px', color: 'var(--text-secondary)', marginTop: '4px' }}>
+                    {klass._count.enrollments} student{klass._count.enrollments === 1 ? '' : 's'}
+                  </div>
+                </div>
+                <div style={{
+                  fontFamily: 'monospace',
+                  fontSize: '18px',
+                  fontWeight: 700,
+                  letterSpacing: '2px',
+                  color: 'var(--accent-primary)',
+                  background: 'var(--bg-tertiary)',
+                  padding: '8px 14px',
+                  borderRadius: '10px',
+                }}>
+                  {klass.code}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/SimpleAuthProvider';
+
+export default function JoinClassPage() {
+  const router = useRouter();
+  const { user, loading, role } = useAuth();
+  const [code, setCode] = useState('');
+  const [isJoining, setIsJoining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [joinedClassName, setJoinedClassName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace('/auth/login');
+      return;
+    }
+    if (role !== 'STUDENT') {
+      router.replace('/catalog');
+    }
+  }, [loading, user, role, router]);
+
+  const handleJoin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim()) return;
+
+    setIsJoining(true);
+    setError(null);
+    setJoinedClassName(null);
+    try {
+      const response = await fetch('/api/classes/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: code.trim() }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || 'Failed to join class');
+      }
+      setJoinedClassName(result.class.name);
+      setCode('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  if (loading || !user || role !== 'STUDENT') {
+    return null;
+  }
+
+  return (
+    <div className="page-container min-h-screen bg-[var(--bg-primary)] text-[var(--text-primary)] flex items-center justify-center" style={{ padding: '48px 24px' }}>
+      <div className="w-full max-w-md mx-auto" style={{
+        background: 'var(--bg-secondary)',
+        borderRadius: '24px',
+        boxShadow: '0 4px 6px var(--shadow-soft), 0 10px 25px var(--shadow-medium)',
+        border: '2px solid var(--border-light)',
+        padding: '40px',
+      }}>
+        <h1 style={{
+          fontSize: '1.75rem',
+          fontWeight: 700,
+          marginBottom: '12px',
+          color: 'var(--text-accent)',
+          fontFamily: 'Playfair Display, serif',
+        }}>
+          Join a class
+        </h1>
+        <p style={{
+          fontSize: '15px',
+          color: 'var(--text-secondary)',
+          marginBottom: '24px',
+          fontFamily: 'Source Serif Pro, Georgia, serif',
+        }}>
+          Enter the code your teacher gave you.
+        </p>
+
+        <form onSubmit={handleJoin} style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => setCode(e.target.value.toUpperCase())}
+            placeholder="e.g. X7K9P2"
+            disabled={isJoining}
+            style={{
+              padding: '14px 16px',
+              borderRadius: '12px',
+              border: '2px solid var(--border-light)',
+              background: 'var(--bg-tertiary)',
+              color: 'var(--text-primary)',
+              fontSize: '18px',
+              fontFamily: 'monospace',
+              letterSpacing: '2px',
+              textAlign: 'center',
+              textTransform: 'uppercase',
+            }}
+          />
+
+          {error && (
+            <div role="alert" style={{ fontSize: '14px', color: '#ef4444', fontWeight: 600, fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+              {error}
+            </div>
+          )}
+
+          {joinedClassName && (
+            <div role="status" style={{ fontSize: '14px', color: '#16a34a', fontWeight: 600, fontFamily: 'Source Serif Pro, Georgia, serif' }}>
+              You've joined {joinedClassName}!
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={isJoining || !code.trim()}
+            style={{
+              width: '100%',
+              padding: '14px 24px',
+              background: 'var(--accent-primary)',
+              color: 'var(--bg-primary)',
+              border: 'none',
+              borderRadius: '16px',
+              fontSize: '16px',
+              fontWeight: 700,
+              fontFamily: 'Source Serif Pro, Georgia, serif',
+              cursor: isJoining ? 'not-allowed' : 'pointer',
+              opacity: isJoining || !code.trim() ? 0.5 : 1,
+            }}
+          >
+            {isJoining ? 'Joining...' : 'Join class'}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => router.push('/catalog')}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: 'var(--text-secondary)',
+              fontSize: '14px',
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          >
+            Skip for now
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/SimpleAuthProvider';
 
+const isTeacherDashboardEnabled = process.env.NEXT_PUBLIC_TEACHER_DASHBOARD === 'true';
+
 export default function JoinClassPage() {
   const router = useRouter();
   const { user, loading, role } = useAuth();
@@ -13,6 +15,10 @@ export default function JoinClassPage() {
   const [joinedClassName, setJoinedClassName] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isTeacherDashboardEnabled) {
+      router.replace('/catalog');
+      return;
+    }
     if (loading) return;
     if (!user) {
       router.replace('/auth/login');
@@ -49,7 +55,7 @@ export default function JoinClassPage() {
     }
   };
 
-  if (loading || !user || role !== 'STUDENT') {
+  if (!isTeacherDashboardEnabled || loading || !user || role !== 'STUDENT') {
     return null;
   }
 

--- a/docs/implementation/TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md
+++ b/docs/implementation/TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Teacher Dashboard — Implementation Plan (July 2026)
 
-**Status: 📋 PLANNED — not started, pending approval to begin Phase 0.**
+**Status: ✅ COMPLETE — all 5 phases built and verified locally, behind `NEXT_PUBLIC_TEACHER_DASHBOARD` (off by default). Not yet pushed/deployed.**
 
 Next feature per the priority order in `TEACHER_FEATURES_FEASIBILITY.md`, which becomes possible now that `role` exists on `User` (see `ROLE_BASED_SIGNUP_IMPLEMENTATION_PLAN.md`).
 
@@ -157,12 +157,13 @@ Dashboard entry point (this is what a `TEACHER`-role user lands on post-login, r
 
 "Enter class code" input on the student's own dashboard, immediate feedback on join success/failure (invalid code, already enrolled).
 
-## Phase 5 — Rollout safety
+## Phase 5 — Rollout safety ✅
 
-- Built and verified against the local Supabase stack first, same as role-based signup — not production.
-- Behind a feature flag, killable instantly, same mechanism as `NEXT_PUBLIC_ROLE_BASED_SIGNUP`.
-- Manual regression check: existing student login/catalog flow unaffected; a `role = null` legacy user (if any remain) isn't broken by the new post-login redirect logic.
-- Merge to `main` only after a real browser click-through: create class → copy code → join as a second test account → see roster update.
+- `NEXT_PUBLIC_TEACHER_DASHBOARD`, same mechanism as `NEXT_PUBLIC_ROLE_BASED_SIGNUP` — off by default. `resolvePostLoginDestination` takes it as an explicit `{ teacherDashboardEnabled }` option (kept as a pure, testable function rather than reading `process.env` internally); `/dashboard`, `/dashboard/classes/[classId]`, and `/join` each redirect to `/catalog` immediately if the flag is off, regardless of role. API routes are intentionally flag-agnostic (same precedent as `create-user`/`set-role`) — the flag only gates the UI surface.
+- Verified both states in a real browser against the local Supabase stack: flag off → a TEACHER-role account logging in lands on `/catalog`, and directly navigating to `/dashboard` bounces back to `/catalog`. Flag on → identical behavior to Phases 3/4 (dashboard, roster, join all work).
+- Known follow-up, out of scope here: Google OAuth login for an existing teacher redirects to `/catalog` unconditionally (`app/auth/callback/route.ts` never called `resolvePostLoginDestination` — pre-existing, not introduced by this feature). Only the password-login path picks up the new flag-gated destination. A teacher can still reach `/dashboard` by URL either way, since the page-level guard is independent of how they logged in.
+- All existing tests still pass; the 5 mobile/tokenizer test failures present throughout this branch are pre-existing and unrelated (none import anything touched by this feature).
+- Not yet merged to `main` or pushed to `origin` — that's a separate step once you're ready.
 
 ## Before Phase 0 starts
 

--- a/docs/implementation/TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md
+++ b/docs/implementation/TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,173 @@
+# Teacher Dashboard — Implementation Plan (July 2026)
+
+**Status: 📋 PLANNED — not started, pending approval to begin Phase 0.**
+
+Next feature per the priority order in `TEACHER_FEATURES_FEASIBILITY.md`, which becomes possible now that `role` exists on `User` (see `ROLE_BASED_SIGNUP_IMPLEMENTATION_PLAN.md`).
+
+**Workflow per phase**: write the test first (red) → implement (green) → run the full test suite → commit. Same discipline as the role-based signup branch — small, independently-revertable commits, not one giant commit at the end.
+
+## How this plan was produced
+
+Two independent research passes (Gemini, Copilot) were run against the same context brief (BookBridge stack, existing `role` field, the three-feature dependency chain: dashboard → book assignment → reading lists) and asked to propose a data model, v1 scope, enrollment flow, permission model, and build order. Both converged independently on the same core architecture — `Class` + `Enrollment` as explicit join tables, join-code enrollment, server-scoped queries — which is a reasonable sanity check on the overall shape.
+
+That output was then verified line-by-line against the actual schema and auth code in this repo, not taken as-is. Five corrections came out of that verification:
+
+1. **ID default**: use `@default(cuid())`, not `uuid()` — every existing model in `prisma/schema.prisma` uses `cuid()`; one of the two proposals didn't know that.
+2. **Auth pattern**: neither tool could see this codebase. The real pattern (`app/api/auth/set-role/route.ts`) is `createClient()` from `@/lib/supabase/server` → `supabase.auth.getUser()` for the authenticated identity, and `servicePrisma` (not a bare Prisma client) for writes. New routes here follow that, not generic `session.user.id` pseudocode.
+3. **`BookAssignment.bookId`**: a real `Book` model already exists (`prisma/schema.prisma:51`). This must be an actual Prisma relation to `Book.id`, not a loose annotated string field.
+4. **Enrollment status**: one proposal's v1 scope included a "remove student from roster" action but its own schema had no field to support a soft removal — adopted the other proposal's `EnrollmentStatus` enum (`ACTIVE` / `ARCHIVED`) to close that gap.
+5. **Naming convention**: newer models (`ESLVocabularyProgress`, `ReadingSession`, `AppTestimonial`) map camelCase fields to snake_case columns via `@map(...)`; older ones (`User`, `Book`) don't. `Class`/`Enrollment` follow the newer convention.
+
+## A scope finding, not from either AI tool
+
+`TEACHER_FEATURES_FEASIBILITY.md` originally described this feature as "reading progress, time spent, completed books, comprehension results — read-only aggregation, low risk" — i.e. a report screen over data that already exists per-user. It didn't account for the fact that **no teacher↔student relationship exists anywhere in the schema.** `User.role` just marks an account as `TEACHER` or `STUDENT`; there is no way today to know which students belong to which teacher. Both research passes independently caught this. So this feature is honestly foundational — closer in size to role-based signup than to a simple report screen — not scope creep introduced by the research.
+
+## Data model
+
+```prisma
+model Class {
+  id          String       @id @default(cuid())
+  name        String
+  code        String       @unique
+  teacherId   String       @map("teacher_id")
+  teacher     User         @relation("TeacherClasses", fields: [teacherId], references: [id], onDelete: Cascade)
+  enrollments Enrollment[]
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
+
+  @@index([teacherId])
+  @@map("classes")
+}
+
+model Enrollment {
+  id        String           @id @default(cuid())
+  classId   String           @map("class_id")
+  studentId String           @map("student_id")
+  class     Class            @relation(fields: [classId], references: [id], onDelete: Cascade)
+  student   User             @relation("StudentEnrollments", fields: [studentId], references: [id], onDelete: Cascade)
+  status    EnrollmentStatus @default(ACTIVE)
+  joinedAt  DateTime         @default(now()) @map("joined_at")
+
+  @@unique([classId, studentId])
+  @@index([classId])
+  @@index([studentId])
+  @@map("enrollments")
+}
+
+enum EnrollmentStatus {
+  ACTIVE
+  ARCHIVED
+}
+```
+
+`User` gains two back-relations (`taughtClasses Class[] @relation("TeacherClasses")`, `enrollments Enrollment[] @relation("StudentEnrollments")`) — purely additive, no existing query changes behavior.
+
+**Why explicit join table, not implicit `students User[]` on `Class`**: an implicit M:N can't hold `status`/`joinedAt` metadata. Adding that later means a destructive migration to rewrite it into an explicit table — cheaper to start explicit.
+
+**Why `Class` as the anchor, not a direct `Teacher–Student` link**: a direct link breaks the moment a student has more than one teacher, changes teachers between years, or belongs to more than one class. Both `BookAssignment` (next feature) and shared reading lists (feature after that) attach naturally to `Class`, not to a teacher-student pair — so anchoring here now avoids a redesign for either.
+
+## Scope — v1
+
+**In scope:**
+- Teacher creates a class (name + generated invite code)
+- Student joins a class by entering the code
+- Teacher views roster (students currently `ACTIVE` in a class)
+- Teacher removes a student from roster (sets `ARCHIVED`, not a hard delete)
+- Basic per-student reading signal on the roster (books read / last activity — computed from existing `ReadingSession` data, not denormalized/cached yet)
+
+**Explicitly deferred:**
+- Book assignment UI (`BookAssignment` model — schema hook only, see below)
+- Shared reading lists
+- Email-based invites (join-code only for v1; email invite can be added later without a schema change)
+- Approval/pending enrollment states (the `EnrollmentStatus` enum leaves room for a future `PENDING` value if needed)
+- Multi-teacher class ownership
+- Any analytics beyond the basic roster signal above
+
+## Enrollment flow
+
+Join code only, no email delivery, no approval queue:
+
+1. Teacher creates a class → backend generates a short, unique, human-readable code.
+2. Teacher shares the code out-of-band (however they already communicate with students).
+3. Student enters the code on their own dashboard → `Enrollment` row created immediately, `status = ACTIVE`.
+
+Chosen over email invites specifically because this codebase's email path (Resend) has already caused two production incidents (see `ROLE_BASED_SIGNUP_DESIGN_RATIONALE.md` items 1–2) — a join code has no delivery dependency to fail. Chosen over an approval queue because that requires a state machine and admin UI this feature doesn't need yet; `EnrollmentStatus` leaves the door open if it's ever needed.
+
+## Permissions
+
+No route trusts a client-supplied role or ID. Every teacher-facing query is scoped server-side through the authenticated session, following the exact pattern in `app/api/auth/set-role/route.ts`:
+
+```ts
+const supabase = await createClient(); // @/lib/supabase/server
+const { data: { user }, error } = await supabase.auth.getUser();
+if (error || !user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+const roster = await servicePrisma.enrollment.findMany({
+  where: { class: { teacherId: user.id, id: classId } },
+  include: { student: { select: { id: true, name: true, email: true } } },
+});
+```
+
+A class lookup that doesn't also filter on `teacherId: user.id` is a bug, not a style choice — it's how a teacher could see another teacher's roster.
+
+## Extensibility hooks (schema only, not built now)
+
+```prisma
+model BookAssignment {
+  id         String    @id @default(cuid())
+  classId    String    @map("class_id")
+  bookId     String    @map("book_id")
+  class      Class     @relation(fields: [classId], references: [id], onDelete: Cascade)
+  book       Book      @relation(fields: [bookId], references: [id])
+  assignedAt DateTime  @default(now()) @map("assigned_at")
+  dueDate    DateTime? @map("due_date")
+
+  @@index([classId])
+  @@map("book_assignments")
+}
+```
+
+Not created in Phase 0 — listed here so the `Class`-as-anchor decision is visibly validated against the next feature before Phase 0 ships, per the design principle above. Actual creation happens when book assignment is built.
+
+## Phase 0 — Schema only, no behavior change
+
+Add `Class`, `Enrollment`, `EnrollmentStatus` to `prisma/schema.prisma`. Purely additive — no existing table or query is touched. Migrate and verify locally against the Supabase stack already running from the role-based signup work (`supabase start`), not production.
+
+**Verification**: migration applies cleanly; seed a mock teacher + class + a few students locally; existing test suite still passes untouched.
+
+## Phase 1 — TDD the invite-code and permission logic
+
+New `lib/classes/generate-class-code.ts` (pure function — code generation + collision-check shape) and `lib/classes/authorize-teacher-class.ts` (pure function — given a user id, class id, and class-with-teacherId record, returns authorized/not), tested first, modeled on the existing `lib/auth/resolve-signup-role.ts` precedent (pure functions, no Supabase mocking).
+
+## Phase 2 — API routes
+
+- `POST /api/classes` — create a class (authenticated teacher only)
+- `GET /api/classes` — list the authenticated teacher's classes
+- `GET /api/classes/[classId]/roster` — roster for one class, teacher-owned only
+- `POST /api/classes/join` — student submits a code, creates their `Enrollment`
+- `DELETE /api/classes/[classId]/roster/[studentId]` — archive an enrollment (soft remove)
+
+Every route follows the `set-role` auth pattern above. Route handlers stay thin, untested I/O wrappers; the authorization/business logic they call is what's unit-tested (same division as the role-based signup routes).
+
+## Phase 3 — Teacher UI
+
+Dashboard entry point (this is what a `TEACHER`-role user lands on post-login, replacing today's placeholder redirect from `resolve-post-login-destination.ts`): class list, create-class form, roster view per class with the remove-student action.
+
+## Phase 4 — Student UI
+
+"Enter class code" input on the student's own dashboard, immediate feedback on join success/failure (invalid code, already enrolled).
+
+## Phase 5 — Rollout safety
+
+- Built and verified against the local Supabase stack first, same as role-based signup — not production.
+- Behind a feature flag, killable instantly, same mechanism as `NEXT_PUBLIC_ROLE_BASED_SIGNUP`.
+- Manual regression check: existing student login/catalog flow unaffected; a `role = null` legacy user (if any remain) isn't broken by the new post-login redirect logic.
+- Merge to `main` only after a real browser click-through: create class → copy code → join as a second test account → see roster update.
+
+## Before Phase 0 starts
+
+A stale local branch `feature/teacher-dashboard` already exists — it predates the role-based signup work and is missing all of it (no `role` column, no auth changes). It should not be reused as-is. Recommend deleting it and starting this work on a fresh branch off current `main`, but that's a confirmation, not something to do unprompted.
+
+## What's next after this feature
+
+Per `TEACHER_FEATURES_FEASIBILITY.md`: one-click book assignment next (built on the `BookAssignment` hook above), then shared reading lists. CEFR level-switching bug fix remains outstanding and independent of this work.

--- a/lib/auth/__tests__/resolve-post-login-destination.test.ts
+++ b/lib/auth/__tests__/resolve-post-login-destination.test.ts
@@ -5,10 +5,8 @@ describe('resolvePostLoginDestination', () => {
     expect(resolvePostLoginDestination('STUDENT')).toBe('/catalog');
   });
 
-  it('sends teachers to the catalog for now (no Teacher Dashboard yet)', () => {
-    // Once the Teacher Dashboard feature ships, this becomes '/dashboard' -
-    // this test should be updated alongside that change, not before.
-    expect(resolvePostLoginDestination('TEACHER')).toBe('/catalog');
+  it('sends teachers to the Teacher Dashboard', () => {
+    expect(resolvePostLoginDestination('TEACHER')).toBe('/dashboard');
   });
 
   it('defaults to the catalog when role is unknown', () => {

--- a/lib/auth/__tests__/resolve-post-login-destination.test.ts
+++ b/lib/auth/__tests__/resolve-post-login-destination.test.ts
@@ -5,8 +5,13 @@ describe('resolvePostLoginDestination', () => {
     expect(resolvePostLoginDestination('STUDENT')).toBe('/catalog');
   });
 
-  it('sends teachers to the Teacher Dashboard', () => {
-    expect(resolvePostLoginDestination('TEACHER')).toBe('/dashboard');
+  it('sends teachers to the Teacher Dashboard when the flag is enabled', () => {
+    expect(resolvePostLoginDestination('TEACHER', { teacherDashboardEnabled: true })).toBe('/dashboard');
+  });
+
+  it('sends teachers to the catalog when the flag is disabled or omitted (killable rollout)', () => {
+    expect(resolvePostLoginDestination('TEACHER', { teacherDashboardEnabled: false })).toBe('/catalog');
+    expect(resolvePostLoginDestination('TEACHER')).toBe('/catalog');
   });
 
   it('defaults to the catalog when role is unknown', () => {

--- a/lib/auth/require-role.ts
+++ b/lib/auth/require-role.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { servicePrisma } from '@/lib/prisma-service';
+
+export type RequireRoleResult =
+  | { userId: string }
+  | { error: NextResponse };
+
+/**
+ * Identifies the caller from the session cookie (never a client-supplied
+ * id) and checks their Prisma `role` - the same dual-write source of truth
+ * set up in app/api/auth/set-role/route.ts. Untested by design, same as
+ * that route: it's a thin I/O wrapper, not business logic.
+ */
+export async function requireRole(role: 'TEACHER' | 'STUDENT'): Promise<RequireRoleResult> {
+  const supabase = await createClient();
+  const { data: { user }, error } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { error: NextResponse.json({ error: 'Not authenticated' }, { status: 401 }) };
+  }
+
+  const dbUser = await servicePrisma.user.findUnique({
+    where: { id: user.id },
+    select: { role: true },
+  });
+
+  if (dbUser?.role !== role) {
+    return {
+      error: NextResponse.json(
+        { error: `${role === 'TEACHER' ? 'Teacher' : 'Student'} role required` },
+        { status: 403 }
+      ),
+    };
+  }
+
+  return { userId: user.id };
+}

--- a/lib/auth/resolve-post-login-destination.ts
+++ b/lib/auth/resolve-post-login-destination.ts
@@ -1,15 +1,9 @@
 import type { SignupRole } from '@/lib/auth/resolve-signup-role';
 
-/**
- * TEACHER currently maps to '/catalog', same as STUDENT - the Teacher
- * Dashboard doesn't exist yet. Once it ships, change TEACHER's entry
- * below to its route; update resolve-post-login-destination.test.ts
- * alongside it.
- */
 export function resolvePostLoginDestination(role: SignupRole | null): string {
   switch (role) {
     case 'TEACHER':
-      return '/catalog';
+      return '/dashboard';
     case 'STUDENT':
       return '/catalog';
     default:

--- a/lib/auth/resolve-post-login-destination.ts
+++ b/lib/auth/resolve-post-login-destination.ts
@@ -1,9 +1,16 @@
 import type { SignupRole } from '@/lib/auth/resolve-signup-role';
 
-export function resolvePostLoginDestination(role: SignupRole | null): string {
+export interface ResolvePostLoginDestinationOptions {
+  teacherDashboardEnabled?: boolean;
+}
+
+export function resolvePostLoginDestination(
+  role: SignupRole | null,
+  options: ResolvePostLoginDestinationOptions = {}
+): string {
   switch (role) {
     case 'TEACHER':
-      return '/dashboard';
+      return options.teacherDashboardEnabled ? '/dashboard' : '/catalog';
     case 'STUDENT':
       return '/catalog';
     default:

--- a/lib/classes/__tests__/authorize-teacher-class.test.ts
+++ b/lib/classes/__tests__/authorize-teacher-class.test.ts
@@ -1,0 +1,30 @@
+import { authorizeTeacherClass } from '@/lib/classes/authorize-teacher-class';
+
+describe('authorizeTeacherClass', () => {
+  it('authorizes the teacher who owns the class', () => {
+    const result = authorizeTeacherClass({
+      requestingUserId: 'teacher-1',
+      klass: { teacherId: 'teacher-1' },
+    });
+    expect(result.authorized).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('rejects a different teacher, without revealing the class exists', () => {
+    const result = authorizeTeacherClass({
+      requestingUserId: 'teacher-2',
+      klass: { teacherId: 'teacher-1' },
+    });
+    expect(result.authorized).toBe(false);
+    expect(result.reason).toBe('not_owner');
+  });
+
+  it('rejects when the class was not found', () => {
+    const result = authorizeTeacherClass({
+      requestingUserId: 'teacher-1',
+      klass: null,
+    });
+    expect(result.authorized).toBe(false);
+    expect(result.reason).toBe('not_found');
+  });
+});

--- a/lib/classes/__tests__/generate-class-code.test.ts
+++ b/lib/classes/__tests__/generate-class-code.test.ts
@@ -1,0 +1,55 @@
+import { generateClassCodeCandidate, generateUniqueClassCode } from '@/lib/classes/generate-class-code';
+
+describe('generateClassCodeCandidate', () => {
+  it('generates a code of the default length', () => {
+    const code = generateClassCodeCandidate();
+    expect(code).toHaveLength(6);
+  });
+
+  it('respects a custom length', () => {
+    const code = generateClassCodeCandidate({ length: 8 });
+    expect(code).toHaveLength(8);
+  });
+
+  it('never includes visually ambiguous characters (0/O, 1/I/L)', () => {
+    // Teachers read these aloud or write them on a whiteboard - a code a
+    // student can't reliably transcribe defeats the point of the flow.
+    for (let i = 0; i < 200; i++) {
+      const code = generateClassCodeCandidate();
+      expect(code).not.toMatch(/[01IOL]/);
+    }
+  });
+
+  it('is deterministic given an injected random source', () => {
+    const alwaysZero = () => 0;
+    const code = generateClassCodeCandidate({ randomFn: alwaysZero });
+    expect(code).toBe(code[0].repeat(6));
+  });
+});
+
+describe('generateUniqueClassCode', () => {
+  it('returns the first candidate when it is not taken', async () => {
+    const isCodeTaken = jest.fn().mockResolvedValue(false);
+    const code = await generateUniqueClassCode(isCodeTaken);
+    expect(code).toHaveLength(6);
+    expect(isCodeTaken).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when a candidate collides, and returns the next free one', async () => {
+    const isCodeTaken = jest.fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const code = await generateUniqueClassCode(isCodeTaken);
+    expect(code).toHaveLength(6);
+    expect(isCodeTaken).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after exhausting maxAttempts rather than looping forever', async () => {
+    const isCodeTaken = jest.fn().mockResolvedValue(true);
+    await expect(
+      generateUniqueClassCode(isCodeTaken, { maxAttempts: 3 })
+    ).rejects.toThrow(/unique class code/i);
+    expect(isCodeTaken).toHaveBeenCalledTimes(3);
+  });
+});

--- a/lib/classes/authorize-teacher-class.ts
+++ b/lib/classes/authorize-teacher-class.ts
@@ -1,0 +1,25 @@
+export interface AuthorizeTeacherClassInput {
+  requestingUserId: string;
+  klass: { teacherId: string } | null;
+}
+
+export interface AuthorizeTeacherClassResult {
+  authorized: boolean;
+  reason?: 'not_found' | 'not_owner';
+}
+
+/**
+ * Collapses "class doesn't exist" and "class exists but isn't yours" into
+ * the same caller-facing result (both `authorized: false`) so a route can
+ * return a uniform 404 without leaking whether a given class id belongs to
+ * someone else. `reason` is for server-side logging only, never the response.
+ */
+export function authorizeTeacherClass(input: AuthorizeTeacherClassInput): AuthorizeTeacherClassResult {
+  if (!input.klass) {
+    return { authorized: false, reason: 'not_found' };
+  }
+  if (input.klass.teacherId !== input.requestingUserId) {
+    return { authorized: false, reason: 'not_owner' };
+  }
+  return { authorized: true };
+}

--- a/lib/classes/generate-class-code.ts
+++ b/lib/classes/generate-class-code.ts
@@ -1,0 +1,41 @@
+// Excludes 0/O, 1/I/L - a code a teacher reads aloud or a student
+// hand-copies from a whiteboard must not depend on font disambiguation.
+const CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+export interface GenerateClassCodeOptions {
+  length?: number;
+  randomFn?: () => number;
+}
+
+export interface GenerateUniqueClassCodeOptions extends GenerateClassCodeOptions {
+  maxAttempts?: number;
+}
+
+export function generateClassCodeCandidate(options: GenerateClassCodeOptions = {}): string {
+  const length = options.length ?? 6;
+  const randomFn = options.randomFn ?? Math.random;
+  let code = '';
+  for (let i = 0; i < length; i++) {
+    code += CODE_ALPHABET[Math.floor(randomFn() * CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+/**
+ * `isCodeTaken` is injected so this stays testable without mocking a
+ * database - callers pass a real uniqueness check (e.g. a Prisma lookup)
+ * in production.
+ */
+export async function generateUniqueClassCode(
+  isCodeTaken: (code: string) => Promise<boolean>,
+  options: GenerateUniqueClassCodeOptions = {}
+): Promise<string> {
+  const maxAttempts = options.maxAttempts ?? 5;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const candidate = generateClassCodeCandidate(options);
+    if (!(await isCodeTaken(candidate))) {
+      return candidate;
+    }
+  }
+  throw new Error(`Could not generate a unique class code after ${maxAttempts} attempts`);
+}

--- a/lib/classes/get-class-roster.ts
+++ b/lib/classes/get-class-roster.ts
@@ -1,0 +1,60 @@
+import { servicePrisma } from '@/lib/prisma-service';
+
+export interface RosterEntry {
+  enrollmentId: string;
+  studentId: string;
+  name: string | null;
+  email: string;
+  joinedAt: Date;
+  booksRead: number;
+  lastActivity: Date | null;
+}
+
+/**
+ * Two queries total regardless of roster size (distinct-book count via raw
+ * SQL since Prisma's groupBy can't express COUNT(DISTINCT ...), last-activity
+ * via groupBy) - not one query per student. See TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md
+ * "Scalability" section.
+ */
+export async function getClassRoster(classId: string): Promise<RosterEntry[]> {
+  const enrollments = await servicePrisma.enrollment.findMany({
+    where: { classId, status: 'ACTIVE' },
+    include: { student: { select: { id: true, name: true, email: true } } },
+    orderBy: { joinedAt: 'asc' },
+  });
+
+  if (enrollments.length === 0) return [];
+
+  const studentIds = enrollments.map((enrollment) => enrollment.studentId);
+
+  const [distinctBookCounts, lastActivity] = await Promise.all([
+    servicePrisma.$queryRaw<{ user_id: string; distinct_books: bigint }[]>`
+      SELECT user_id, COUNT(DISTINCT book_id) AS distinct_books
+      FROM reading_sessions
+      WHERE user_id = ANY(${studentIds})
+      GROUP BY user_id
+    `,
+    servicePrisma.readingSession.groupBy({
+      by: ['userId'],
+      where: { userId: { in: studentIds } },
+      _max: { sessionStart: true },
+    }),
+  ]);
+
+  const booksReadByStudent = new Map(
+    distinctBookCounts.map((row) => [row.user_id, Number(row.distinct_books)])
+  );
+  const lastActivityByStudent = new Map(
+    lastActivity.map((row) => [row.userId, row._max.sessionStart])
+  );
+
+  return enrollments.map((enrollment) => ({
+    enrollmentId: enrollment.id,
+    studentId: enrollment.studentId,
+    name: enrollment.student.name,
+    email: enrollment.student.email,
+    joinedAt: enrollment.joinedAt,
+    booksRead: booksReadByStudent.get(enrollment.studentId) ?? 0,
+    lastActivity: lastActivityByStudent.get(enrollment.studentId) ?? null,
+  }));
+}

--- a/prisma/migrations/20260727070925_add_class_enrollment/migration.sql
+++ b/prisma/migrations/20260727070925_add_class_enrollment/migration.sql
@@ -1,0 +1,54 @@
+-- Teacher Dashboard Phase 0: Class + Enrollment foundation.
+-- Additive only: two new tables, one new enum, one new FK on each new
+-- table pointing at existing users(id). No existing table is altered.
+-- See docs/implementation/TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md.
+
+-- CreateEnum
+CREATE TYPE "public"."EnrollmentStatus" AS ENUM ('ACTIVE', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "public"."classes" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "teacher_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "classes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."enrollments" (
+    "id" TEXT NOT NULL,
+    "class_id" TEXT NOT NULL,
+    "student_id" TEXT NOT NULL,
+    "status" "public"."EnrollmentStatus" NOT NULL DEFAULT 'ACTIVE',
+    "joined_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "enrollments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "classes_code_key" ON "public"."classes"("code");
+
+-- CreateIndex
+CREATE INDEX "classes_teacher_id_idx" ON "public"."classes"("teacher_id");
+
+-- CreateIndex
+CREATE INDEX "enrollments_class_id_idx" ON "public"."enrollments"("class_id");
+
+-- CreateIndex
+CREATE INDEX "enrollments_student_id_idx" ON "public"."enrollments"("student_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "enrollments_class_id_student_id_key" ON "public"."enrollments"("class_id", "student_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."classes" ADD CONSTRAINT "classes_teacher_id_fkey" FOREIGN KEY ("teacher_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."enrollments" ADD CONSTRAINT "enrollments_class_id_fkey" FOREIGN KEY ("class_id") REFERENCES "public"."classes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."enrollments" ADD CONSTRAINT "enrollments_student_id_fkey" FOREIGN KEY ("student_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,8 +31,44 @@ model User {
   readingSessions ReadingSession[]
   readingPositions ReadingPosition[]
   feedback Feedback[]
+  taughtClasses    Class[]          @relation("TeacherClasses")
+  enrollments      Enrollment[]     @relation("StudentEnrollments")
 
   @@map("users")
+}
+
+model Class {
+  id          String       @id @default(cuid())
+  name        String
+  code        String       @unique
+  teacherId   String       @map("teacher_id")
+  teacher     User         @relation("TeacherClasses", fields: [teacherId], references: [id], onDelete: Cascade)
+  enrollments Enrollment[]
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
+
+  @@index([teacherId])
+  @@map("classes")
+}
+
+model Enrollment {
+  id        String           @id @default(cuid())
+  classId   String           @map("class_id")
+  studentId String           @map("student_id")
+  class     Class            @relation(fields: [classId], references: [id], onDelete: Cascade)
+  student   User             @relation("StudentEnrollments", fields: [studentId], references: [id], onDelete: Cascade)
+  status    EnrollmentStatus @default(ACTIVE)
+  joinedAt  DateTime         @default(now()) @map("joined_at")
+
+  @@unique([classId, studentId])
+  @@index([classId])
+  @@index([studentId])
+  @@map("enrollments")
+}
+
+enum EnrollmentStatus {
+  ACTIVE
+  ARCHIVED
 }
 
 model Subscription {


### PR DESCRIPTION
---

Summary
- Adds Class + Enrollment to the schema so teachers and students can be linked — a relationship that didn't exist before this branch.
- Teacher UI: /dashboard (create/list classes, generated invite code) and /dashboard/classes/[classId] (roster with reading-progress signal, remove-student).
- Student UI: /join (enter a class code to enroll).
- Everything is gated behind NEXT_PUBLIC_TEACHER_DASHBOARD (off by default) — merging this does not turn the feature on in production by itself.

Test plan
- [x] Migration applied and verified against a local Supabase stack only (never production)
- [x] TDD'd pure functions: invite-code generation (excludes ambiguous characters), teacher-ownership authorization
- [x] All API routes scoped server-side to the authenticated user (no client-trusted IDs), no N+1 queries on the roster
- [x] Full teacher → student → teacher round trip verified in a real browser: create class → get code → join via code → roster updates → remove works
- [x] Feature flag verified both ways: off → /dashboard and /join redirect to /catalog regardless of role; on → identical to normal behavior
- [x] Existing test suite passes (pre-existing, unrelated mobile/tokenizer failures untouched by this branch)
- [ ] Set NEXT_PUBLIC_TEACHER_DASHBOARD=true in Render when ready to actually enable this in production (separate, manual step)

Known follow-up, not fixed in this PR
Google OAuth login for an existing teacher still lands on /catalog, not /dashboard — app/auth/callback/route.ts doesn't use the new flag-gated redirect logic. Pre-existing gap in the OAuth callback path, not introduced by this branch; a teacher can still reach /dashboard directly by URL.

Full detail: docs/implementation/TEACHER_DASHBOARD_IMPLEMENTATION_PLAN.md
